### PR TITLE
Fix escaped newlines in XML debug tests

### DIFF
--- a/modules/Debug.lua
+++ b/modules/Debug.lua
@@ -309,6 +309,12 @@ function Wise:PopulateDebugTests()
         if type(testInstructions) == "string" then
             testInstructions = string.gsub(testInstructions, "\\n", "\n")
         end
+        if type(testAction) == "string" then
+            testAction = string.gsub(testAction, "\\n", "\n")
+        end
+        if type(testClearAction) == "string" then
+            testClearAction = string.gsub(testClearAction, "\\n", "\n")
+        end
 
         local btn = buttons[i]
         if not btn then

--- a/tests.xml
+++ b/tests.xml
@@ -103,4 +103,13 @@
             <KeyValue key="clearAction" value="" type="string"/>
         </KeyValues>
     </Frame>
+
+    <Frame name="WiseDebugTest_NewlineTest" inherits="WiseDebugTestsData">
+        <KeyValues>
+            <KeyValue key="testName" value="Newline Processing Test" type="string"/>
+            <KeyValue key="instructions" value="This test verifies that escaped newlines in the 'action' attribute are processed correctly.\n1. Run the test.\n2. Verify that two separate print statements are executed (check the chat frame)." type="string"/>
+            <KeyValue key="action" value="print('Executing Line 1')\nprint('Executing Line 2')" type="string"/>
+            <KeyValue key="clearAction" value="print('Clearing Line 1')\nprint('Clearing Line 2')" type="string"/>
+        </KeyValues>
+    </Frame>
 </Ui>


### PR DESCRIPTION
This change ensures that escaped newlines (\n) in XML string values for debug tests are correctly converted into actual newline characters. This was already being done for 'testInstructions' but was missing for 'testAction' and 'testClearAction', which often contain multi-line Lua code.

Modified files:
- modules/Debug.lua: Added string.gsub calls for testAction and testClearAction.
- tests.xml: Added a new test case 'Newline Processing Test' that uses multi-line action scripts.

---
*PR created automatically by Jules for task [381797181125928058](https://jules.google.com/task/381797181125928058) started by @claytonkimber*