### PR TITLE
Fix cooldown overlay layering and text visibility

### DIFF
--- a/core/GUI.lua
+++ b/core/GUI.lua
@@ -5659,9 +5659,12 @@ function Wise:UpdateButtonCooldown(btn)
         if not groupName then groupName = parent.groupName end
     end
 
-    btn.cooldown:SetHideCountdownNumbers(true)
+    local _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, showCountdownText = Wise:GetGroupDisplaySettings(groupName)
+
+    -- If Wise's custom countdown text is disabled, allow Blizzard/OmniCC to show text by passing false to SetHideCountdownNumbers
+    btn.cooldown:SetHideCountdownNumbers(showCountdownText)
     if visualClone and visualClone.cooldown then
-        visualClone.cooldown:SetHideCountdownNumbers(true)
+        visualClone.cooldown:SetHideCountdownNumbers(showCountdownText)
     end
 
     -- Determine active state: for DurationObject path, check if cooldown frame is showing

--- a/core/Text.lua
+++ b/core/Text.lua
@@ -46,32 +46,39 @@ end
 function Wise:Text_CreateFontStrings(btn)
     if btn._textReady then return end
 
+    if not btn.textFrame then
+        btn.textFrame = CreateFrame("Frame", nil, btn)
+        btn.textFrame:SetAllPoints(btn)
+        -- Ensure textFrame renders above the cooldown overlay
+        btn.textFrame:SetFrameLevel(btn:GetFrameLevel() + 5)
+    end
+
     -- Charges / Item Count
     if not btn.count then
-        btn.count = btn:CreateFontString(nil, "OVERLAY", "NumberFontNormalSmall")
+        btn.count = btn.textFrame:CreateFontString(nil, "OVERLAY", "NumberFontNormalSmall")
     end
 
     -- Keybind (slot-level)
     if not btn.keybind then
-        btn.keybind = btn:CreateFontString(nil, "OVERLAY", "NumberFontNormalSmall")
+        btn.keybind = btn.textFrame:CreateFontString(nil, "OVERLAY", "NumberFontNormalSmall")
         btn.keybind:SetShadowOffset(1, -1)
     end
 
     -- Interface Keybind (group-level toggle binding)
     if not btn.interfaceKeybind then
-        btn.interfaceKeybind = btn:CreateFontString(nil, "OVERLAY", "NumberFontNormalSmall")
+        btn.interfaceKeybind = btn.textFrame:CreateFontString(nil, "OVERLAY", "NumberFontNormalSmall")
         btn.interfaceKeybind:SetShadowOffset(1, -1)
     end
 
     -- Countdown (new)
     if not btn.countdown then
-        btn.countdown = btn:CreateFontString(nil, "OVERLAY", "NumberFontNormalSmall")
+        btn.countdown = btn.textFrame:CreateFontString(nil, "OVERLAY", "NumberFontNormalSmall")
         -- Default to center, but will be updated by Text_UpdateCountdown
     end
 
     -- Custom Text (stub – not populated yet, but the FontString is ready)
     if not btn.customText then
-        btn.customText = btn:CreateFontString(nil, "OVERLAY", "NumberFontNormalSmall")
+        btn.customText = btn.textFrame:CreateFontString(nil, "OVERLAY", "NumberFontNormalSmall")
     end
 
     btn._textReady = true


### PR DESCRIPTION
Resolves an issue where the cooldown overlay was drawing on top of button text elements (keybinds, charges, countdown text), obscuring them until the cooldown was finished. Also fixes a bug where native cooldown text (like OmniCC) was permanently disabled for non-charge abilities.

---
*PR created automatically by Jules for task [993870145006876349](https://jules.google.com/task/993870145006876349) started by @claytonkimber*