### PR TITLE
fix: disable hover highlight and scale for hidden empty slots

### DIFF
--- a/Wise.lua
+++ b/Wise.lua
@@ -1119,6 +1119,14 @@ function frame:OnEvent(event, arg1)
                 end
             end
         end
+        -- Register with MechanicLib for external data logging
+        local MechanicLib = LibStub and LibStub("MechanicLib-1.0", true)
+        if MechanicLib then
+            local tocVersion = C_AddOns.GetAddOnMetadata(addonName, "Version") or "unknown"
+            MechanicLib:Register("Wise", { version = tocVersion })
+            Wise.MechanicLib = MechanicLib
+        end
+
         -- Initialize modules if needed
         self:UnregisterEvent("ADDON_LOADED")
     elseif event == "PLAYER_LOGIN" then

--- a/Wise.lua
+++ b/Wise.lua
@@ -645,7 +645,16 @@ function Wise:Initialize()
     end
 
     print("|cff00ccffWise|r Loaded. Type /wise to open options.")
-    
+
+    -- Log to MechanicLib debug buffer (visible even when debug mode is off)
+    if Wise.debugBuffer then
+        local tocVersion = C_AddOns.GetAddOnMetadata(addonName, "Version") or "unknown"
+        table.insert(Wise.debugBuffer, { msg = "Wise v" .. tocVersion .. " initialized", time = GetTime() })
+    end
+    if Wise.MechanicLib and Wise.MechanicLib.Log then
+        Wise.MechanicLib:Log("Wise", "Initialized", Wise.MechanicLib.Categories and Wise.MechanicLib.Categories.CORE or nil)
+    end
+
     -- Cache current character info
     if Wise.UpdateCharacterInfo then
         Wise:UpdateCharacterInfo()
@@ -1119,11 +1128,85 @@ function frame:OnEvent(event, arg1)
                 end
             end
         end
-        -- Register with MechanicLib for external data logging
+        -- Register with MechanicLib for full Mechanic integration
         local MechanicLib = LibStub and LibStub("MechanicLib-1.0", true)
         if MechanicLib then
             local tocVersion = C_AddOns.GetAddOnMetadata(addonName, "Version") or "unknown"
-            MechanicLib:Register("Wise", { version = tocVersion })
+
+            -- Debug buffer for Mechanic console
+            Wise.debugBuffer = Wise.debugBuffer or {}
+
+            MechanicLib:Register("Wise", {
+                version = tocVersion,
+
+                -- Console: expose debug buffer for Mechanic's pull model
+                getDebugBuffer = function()
+                    return Wise.debugBuffer
+                end,
+                clearDebugBuffer = function()
+                    if Wise.debugBuffer then
+                        wipe(Wise.debugBuffer)
+                    end
+                end,
+
+                -- Inspect: register key frames for Mechanic's frame watch list
+                inspect = {
+                    getWatchFrames = function()
+                        local frames = {}
+                        if Wise.frames then
+                            for groupName, f in pairs(Wise.frames) do
+                                table.insert(frames, {
+                                    label = "Group: " .. groupName,
+                                    frame = f,
+                                    property = "Visibility",
+                                })
+                            end
+                        end
+                        if Wise.DebugFrame then
+                            table.insert(frames, {
+                                label = "Debug Panel",
+                                frame = Wise.DebugFrame,
+                                property = "Visibility",
+                            })
+                        end
+                        return frames
+                    end,
+                },
+
+                -- Tools: quick actions panel in Mechanic's Tools tab
+                tools = {
+                    createPanel = function(container)
+                        Wise:CreateMechanicToolsPanel(container)
+                    end,
+                },
+
+                -- Settings exposed in Mechanic UI
+                settings = {
+                    debugMode = {
+                        type = "toggle",
+                        name = "Debug Mode",
+                        get = function() return WiseDB and WiseDB.settings and WiseDB.settings.debug end,
+                        set = function(v)
+                            if WiseDB and WiseDB.settings then
+                                WiseDB.settings.debug = v
+                                if Wise.ToggleDebugInterface then
+                                    Wise:ToggleDebugInterface(v)
+                                end
+                            end
+                        end,
+                    },
+                    showKeybinds = {
+                        type = "toggle",
+                        name = "Show Keybinds",
+                        get = function() return WiseDB and WiseDB.settings and WiseDB.settings.showKeybinds end,
+                        set = function(v)
+                            if WiseDB and WiseDB.settings then
+                                WiseDB.settings.showKeybinds = v
+                            end
+                        end,
+                    },
+                },
+            })
             Wise.MechanicLib = MechanicLib
         end
 
@@ -1651,6 +1734,89 @@ SlashCmdList["WISE"] = function(msg)
     else
         print("|cff00ccff[Wise]|r Options not loaded properly.")
     end
+end
+
+-- Mechanic Tools Panel (shown in Mechanic's Tools tab)
+function Wise:CreateMechanicToolsPanel(container)
+    local function CreateToolButton(parent, x, y, width, text, onClick)
+        local btn = CreateFrame("Button", nil, parent, "UIPanelButtonTemplate")
+        btn:SetPoint("TOPLEFT", parent, "TOPLEFT", x, y)
+        btn:SetSize(width, 24)
+        btn:SetText(text)
+        btn:SetScript("OnClick", onClick)
+        return btn
+    end
+
+    local title = container:CreateFontString(nil, "OVERLAY", "GameFontNormalLarge")
+    title:SetPoint("TOPLEFT", 10, -10)
+    title:SetText("Wise Tools")
+
+    local desc = container:CreateFontString(nil, "OVERLAY", "GameFontHighlight")
+    desc:SetPoint("TOPLEFT", 10, -35)
+    desc:SetText("Quick actions for Wise action bar addon.")
+
+    -- Row 1: Options & Edit Mode
+    local row1Label = container:CreateFontString(nil, "OVERLAY", "GameFontNormal")
+    row1Label:SetPoint("TOPLEFT", 10, -65)
+    row1Label:SetText("Panels:")
+
+    CreateToolButton(container, 80, -60, 120, "Open Options", function()
+        if Wise.ToggleOptions then Wise:ToggleOptions() end
+    end)
+
+    CreateToolButton(container, 205, -60, 120, "Toggle Edit Mode", function()
+        if not InCombatLockdown() and Wise.ToggleEditMode then
+            Wise:ToggleEditMode()
+        else
+            print("|cff00ccffWise:|r Cannot toggle edit mode in combat.")
+        end
+    end)
+
+    -- Row 2: Debug
+    local row2Label = container:CreateFontString(nil, "OVERLAY", "GameFontNormal")
+    row2Label:SetPoint("TOPLEFT", 10, -100)
+    row2Label:SetText("Debug:")
+
+    CreateToolButton(container, 80, -95, 120, "Toggle Debug", function()
+        if WiseDB and WiseDB.settings then
+            WiseDB.settings.debug = not WiseDB.settings.debug
+            if Wise.ToggleDebugInterface then
+                Wise:ToggleDebugInterface(WiseDB.settings.debug)
+            end
+            print("|cff00ccffWise:|r Debug " .. (WiseDB.settings.debug and "ON" or "OFF"))
+        end
+    end)
+
+    CreateToolButton(container, 205, -95, 120, "Bug Report", function()
+        if Wise.ShowBugReportWindow then
+            Wise:ShowBugReportWindow()
+        end
+    end)
+
+    -- Row 3: Interfaces info
+    local row3Label = container:CreateFontString(nil, "OVERLAY", "GameFontNormal")
+    row3Label:SetPoint("TOPLEFT", 10, -135)
+    row3Label:SetText("Info:")
+
+    CreateToolButton(container, 80, -130, 120, "List Interfaces", function()
+        if WiseDB and WiseDB.groups then
+            local count = 0
+            for name, g in pairs(WiseDB.groups) do
+                local status = (Wise.frames and Wise.frames[name] and Wise.frames[name]:IsShown()) and "|cff00ff00shown|r" or "|cffff0000hidden|r"
+                print(string.format("|cff00ccffWise:|r  %s [%s] %s", name, g.type or "?", status))
+                count = count + 1
+            end
+            print(string.format("|cff00ccffWise:|r %d interface(s) total.", count))
+        end
+    end)
+
+    CreateToolButton(container, 205, -130, 120, "Demo Tour", function()
+        if Wise.Demo then Wise.Demo:Start() end
+    end)
+
+    local footer = container:CreateFontString(nil, "OVERLAY", "GameFontDisableSmall")
+    footer:SetPoint("BOTTOM", 0, 10)
+    footer:SetText("Use /wise for more options.")
 end
 
 function Wise:ToggleOptions()

--- a/Wise.toc
+++ b/Wise.toc
@@ -8,7 +8,7 @@
 ## Version: @project-version@
 ## X-Curse-Project-ID: 1473207
 ## SavedVariables: WiseDB
-## OptionalDeps: LargerMacroIconSelection, Masque
+## OptionalDeps: LargerMacroIconSelection, Masque, MechanicLib
 ## IconTexture: Interface\AddOns\Wise\Media\WiseLogoSquare_512.tga
 
 # Libraries

--- a/core/GUI.lua
+++ b/core/GUI.lua
@@ -774,12 +774,7 @@ local HOVER_GLOW_ALPHA = 0.5
 local function IsHiddenEmptySlot(btn)
     local btnMeta = Wise.buttonMeta and Wise.buttonMeta[btn]
     local btnActionType = (btnMeta and btnMeta.actionType) or btn.actionType
-    local groupName = btn.groupName or (btn:GetParent() and btn:GetParent().groupName)
-    if groupName and btnActionType == "empty" then
-        local _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, btnHideEmpty = Wise:GetGroupDisplaySettings(groupName)
-        return btnHideEmpty == true
-    end
-    return false
+    return btnActionType == "empty"
 end
 
 local function CreateHoverGlow(parent)
@@ -3276,7 +3271,7 @@ function Wise:UpdateGroupDisplay(name, instanceId, overrideOpts)
                 local conflictStrategy = validStates.conflictStrategy or "priority"
                 local chosenIdx = Wise:EvaluateSlotConditions(validStates, conflictStrategy, nil)
                 local actionData = chosenIdx and validStates[chosenIdx] or validStates[1]
-    
+
                 if actionData then
                     -- Check category metadata filter ONLY for the options UI, not the bar renderer itself.
                     local shouldShow = true
@@ -3308,12 +3303,21 @@ function Wise:UpdateGroupDisplay(name, instanceId, overrideOpts)
                         end
                     else
                         -- Static interfaces: preserve slot positions to prevent collapsing.
-                        if Wise.editMode or isKnown then
-                            table.insert(actionsToShow, {data = actionData, known = isKnown, categoryMatch = true, slot = slotIdx, states = validStates, conflictStrategy = conflictStrategy, resetOnCombat = validStates.resetOnCombat, suppressErrors = validStates.suppressErrors, pressAndHold = validStates.pressAndHold, activeState = chosenIdx})
-                        else
-                            -- Action not known on this character: insert empty placeholder to hold the slot position
-                            table.insert(actionsToShow, {data = {type="empty", value=nil}, known = true, categoryMatch = true, slot = slotIdx})
+                        -- If the chosen state is not known, try to find another valid state that IS known
+                        -- (e.g. conditional override bar won priority but isn't available — fall back to a real spell)
+                        if not isKnown and not Wise.editMode and #validStates > 1 then
+                            for fallbackIdx, fallbackState in ipairs(validStates) do
+                                if fallbackIdx ~= chosenIdx and Wise:IsActionKnown(fallbackState.type, fallbackState.value) then
+                                    chosenIdx = fallbackIdx
+                                    actionData = fallbackState
+                                    isKnown = true
+                                    break
+                                end
+                            end
                         end
+                        -- Always preserve the slot with its actual data (known actions render normally,
+                        -- unknown ones render desaturated). Only user-placed "empty" type slots go invisible.
+                        table.insert(actionsToShow, {data = actionData, known = isKnown, categoryMatch = true, slot = slotIdx, states = validStates, conflictStrategy = conflictStrategy, resetOnCombat = validStates.resetOnCombat, suppressErrors = validStates.suppressErrors, pressAndHold = validStates.pressAndHold, activeState = chosenIdx})
                     end
                 end
             elseif not isDynamic then
@@ -3986,21 +3990,15 @@ function Wise:UpdateGroupDisplay(name, instanceId, overrideOpts)
         btn.isValid = isValid
         
         local isEmptySlot = (aType == "empty")
-        if hideEmptySlots and isEmptySlot then
+        if isEmptySlot then
+            -- Empty slots are pure space maintainers — completely invisible
+            btn:SetAlpha(0)
             btn:EnableMouse(false)
-            btn.icon:SetAlpha(0)
-            if btn.cooldown then btn.cooldown:SetAlpha(0) end
-            if btn.activeHighlight then btn.activeHighlight:SetAlpha(0) end
-            if btn:GetNormalTexture() then btn:GetNormalTexture():SetAlpha(0) end
-            if btn.count then btn.count:SetAlpha(0) end
-            if btn.keybind then btn.keybind:SetAlpha(0) end
+            if btn._textOverlay then btn._textOverlay:Hide() end
         else
+            btn:SetAlpha(1)
             btn:EnableMouse(true)
-            if btn.cooldown then btn.cooldown:SetAlpha(1) end
-            if btn.activeHighlight then btn.activeHighlight:SetAlpha(1) end
-            if btn:GetNormalTexture() then btn:GetNormalTexture():SetAlpha(1) end
-            if btn.count then btn.count:SetAlpha(1) end
-            if btn.keybind then btn.keybind:SetAlpha(1) end
+            if btn.activeHighlight then btn.activeHighlight:Hide() end
 
             if isValid then
                 -- Initial state saturated; Usability check will refine this later
@@ -4144,21 +4142,13 @@ function Wise:UpdateGroupDisplay(name, instanceId, overrideOpts)
                  end
              end
              
-             -- Apply Desaturation (same as real button)
+             -- Empty slots are pure space maintainers — completely invisible
              local vIsEmpty = (actionData.type == "empty")
-             if visualHideEmpty and vIsEmpty then
-                 vBtn.icon:SetAlpha(0)
-                 if vBtn.cooldown then vBtn.cooldown:SetAlpha(0) end
-                 if vBtn.activeHighlight then vBtn.activeHighlight:SetAlpha(0) end
-                 if vBtn:GetNormalTexture() then vBtn:GetNormalTexture():SetAlpha(0) end
-                 if vBtn.count then vBtn.count:SetAlpha(0) end
-                 if vBtn.keybind then vBtn.keybind:SetAlpha(0) end
+             if vIsEmpty then
+                 vBtn:SetAlpha(0)
              else
-                 if vBtn.cooldown then vBtn.cooldown:SetAlpha(1) end
-                 if vBtn.activeHighlight then vBtn.activeHighlight:SetAlpha(1) end
-                 if vBtn:GetNormalTexture() then vBtn:GetNormalTexture():SetAlpha(1) end
-                 if vBtn.count then vBtn.count:SetAlpha(1) end
-                 if vBtn.keybind then vBtn.keybind:SetAlpha(1) end
+                 vBtn:SetAlpha(1)
+                 if vBtn.activeHighlight then vBtn.activeHighlight:Hide() end
                  if isKnown and categoryMatch then
                     vBtn.icon:SetDesaturated(false)
                     vBtn.icon:SetAlpha(1)
@@ -4626,6 +4616,24 @@ function Wise:UpdateGroupDisplay(name, instanceId, overrideOpts)
                                 btn.actionValue = state.value
                                 btn.actionData = state
 
+                                -- Apply/remove empty slot visual treatment (alpha is safe in combat, EnableMouse is not)
+                                if state.type == "empty" then
+                                    btn:SetAlpha(0)
+                                    if canSetAttrs then btn:EnableMouse(false) end
+                                else
+                                    btn:SetAlpha(1)
+                                    if canSetAttrs then btn:EnableMouse(true) end
+                                    -- Restore keybinds when switching away from empty
+                                    local _, _, _, showKeybinds, _, _, _, _, _, _, _, _, _, _, _, _, _, showInterfaceKeybind = Wise:GetGroupDisplaySettings(f.groupName or name)
+                                    Wise:Text_UpdateKeybind(btn, f.groupName or name, showKeybinds)
+                                    Wise:Text_UpdateInterfaceKeybind(btn, f.groupName or name, showInterfaceKeybind)
+                                    local vClone = meta.visualClone or btn.visualClone
+                                    if vClone then
+                                        Wise:Text_UpdateKeybind(vClone, f.groupName or name, showKeybinds)
+                                        Wise:Text_UpdateInterfaceKeybind(vClone, f.groupName or name, showInterfaceKeybind)
+                                    end
+                                end
+
                                 -- Update secure attributes when not in combat
                                 -- BUT NOT for sequence strategy: the PreClick secure snippet
                                 -- manages type/macrotext exclusively for sequences.
@@ -4638,7 +4646,9 @@ function Wise:UpdateGroupDisplay(name, instanceId, overrideOpts)
                                     btn:SetAttribute("macrotext", nil)
                                     btn:SetAttribute("clickbutton", nil)
                                     btn:SetAttribute("type", sType)
-                                    btn:SetAttribute(sAttr, sValue)
+                                    if sAttr then
+                                        btn:SetAttribute(sAttr, sValue)
+                                    end
                                 end
 
                                 -- Update cooldown tracking for new active state
@@ -4664,6 +4674,19 @@ function Wise:UpdateGroupDisplay(name, instanceId, overrideOpts)
                                 meta.actionValue = state.value
                                 meta.actionData = state
                                 Wise:UpdateButtonCooldown(btn)
+
+                                -- Sync visual clone
+                                local vClone = meta.visualClone or btn.visualClone
+                                if vClone then
+                                    if state.type == "empty" then
+                                        vClone:SetAlpha(0)
+                                    else
+                                        vClone:SetAlpha(1)
+                                        if vClone.icon then
+                                            vClone.icon:SetTexture(Wise:GetActionIcon(state.type, state.value, state))
+                                        end
+                                    end
+                                end
                             end
                         end
                     end
@@ -4896,15 +4919,27 @@ function Wise:ApplyLayout(frame, type, count, groupName)
     for i=1, count do
         local btn = buttons[i]
         btn:Show()
-        
-        -- Update Keybind Display via Text
-        Wise:Text_UpdateKeybind(btn, groupName, showKeybinds)
-        Wise:Text_UpdateInterfaceKeybind(btn, groupName, showInterfaceKeybind)
-        
+
+        -- Skip keybind display for empty slots (they are invisible space maintainers)
+        local btnIsEmpty = btn.actionType == "empty"
+        if not btnIsEmpty then
+            -- Update Keybind Display via Text
+            Wise:Text_UpdateKeybind(btn, groupName, showKeybinds)
+            Wise:Text_UpdateInterfaceKeybind(btn, groupName, showInterfaceKeybind)
+        else
+            if btn.keybind then btn.keybind:Hide() end
+            if btn.interfaceKeybind then btn.interfaceKeybind:Hide() end
+        end
+
         -- Sync keybind and interface keybind to visual clone via Text module
         if btn.visualClone then
-            Wise:Text_UpdateKeybind(btn.visualClone, groupName, showKeybinds)
-            Wise:Text_UpdateInterfaceKeybind(btn.visualClone, groupName, showInterfaceKeybind)
+            if not btnIsEmpty then
+                Wise:Text_UpdateKeybind(btn.visualClone, groupName, showKeybinds)
+                Wise:Text_UpdateInterfaceKeybind(btn.visualClone, groupName, showInterfaceKeybind)
+            else
+                if btn.visualClone.keybind then btn.visualClone.keybind:Hide() end
+                if btn.visualClone.interfaceKeybind then btn.visualClone.interfaceKeybind:Hide() end
+            end
         end
     end
 
@@ -5414,7 +5449,7 @@ function Wise:UpdateBindings()
         if f and f.buttons then
             local _, _, _, showKeybinds, _, _, _, _, _, _, _, _, _, _, _, _, _, showInterfaceKeybind = Wise:GetGroupDisplaySettings(name)
             for _, btn in ipairs(f.buttons) do
-                if btn:IsShown() then
+                if btn:IsShown() and btn.actionType ~= "empty" then
                     Wise:Text_UpdateKeybind(btn, name, showKeybinds)
                     Wise:Text_UpdateInterfaceKeybind(btn, name, showInterfaceKeybind)
                 end
@@ -6311,7 +6346,9 @@ function Wise:ResetSequences()
                         btn:SetAttribute("macrotext", nil)
                         btn:SetAttribute("clickbutton", nil)
                         btn:SetAttribute("type", sType)
-                        btn:SetAttribute(sAttr, sValue)
+                        if sAttr then
+                            btn:SetAttribute(sAttr, sValue)
+                        end
                     end
                 end
             end

--- a/core/GUI.lua
+++ b/core/GUI.lua
@@ -771,6 +771,17 @@ end
 local HOVER_SCALE = 1.05
 local HOVER_GLOW_ALPHA = 0.5
 
+local function IsHiddenEmptySlot(btn)
+    local btnMeta = Wise.buttonMeta and Wise.buttonMeta[btn]
+    local btnActionType = (btnMeta and btnMeta.actionType) or btn.actionType
+    local groupName = btn.groupName or (btn:GetParent() and btn:GetParent().groupName)
+    if groupName and btnActionType == "empty" then
+        local _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, btnHideEmpty = Wise:GetGroupDisplaySettings(groupName)
+        return btnHideEmpty == true
+    end
+    return false
+end
+
 local function CreateHoverGlow(parent)
     local glow = CreateFrame("Frame", nil, parent)
     glow:SetFrameLevel(parent:GetFrameLevel() + 3)
@@ -795,6 +806,8 @@ local function CreateHoverGlow(parent)
 end
 
 local function ShowHoverGlow(btn)
+    if IsHiddenEmptySlot(btn) then return end
+
     if not btn._hoverGlow then
         btn._hoverGlow = CreateHoverGlow(btn)
     end
@@ -825,6 +838,8 @@ local function HideHoverGlow(btn)
 end
 
 local function ApplyHoverScale(btn, scale)
+    if IsHiddenEmptySlot(btn) then return end
+
     if btn.icon then
         btn.icon:SetScale(scale)
     end
@@ -840,6 +855,8 @@ function Wise:AddHoverIndication(btn)
     if not btn then return end
 
     btn:HookScript("OnEnter", function(self)
+        if IsHiddenEmptySlot(self) then return end
+
         local parentFrame = self:GetParent()
         local isListLayout = parentFrame and parentFrame.effectiveDisplayType == "list"
         local isLineLayout = parentFrame and parentFrame.effectiveDisplayType == "line"

--- a/core/Text.lua
+++ b/core/Text.lua
@@ -46,32 +46,40 @@ end
 function Wise:Text_CreateFontStrings(btn)
     if btn._textReady then return end
 
+    -- Create an overlay frame above the cooldown so text is never hidden by the swipe
+    if not btn._textOverlay then
+        btn._textOverlay = CreateFrame("Frame", nil, btn)
+        btn._textOverlay:SetAllPoints()
+        btn._textOverlay:SetFrameLevel((btn.cooldown and btn.cooldown:GetFrameLevel() or btn:GetFrameLevel()) + 2)
+    end
+    local overlay = btn._textOverlay
+
     -- Charges / Item Count
     if not btn.count then
-        btn.count = btn:CreateFontString(nil, "OVERLAY", "NumberFontNormalSmall")
+        btn.count = overlay:CreateFontString(nil, "OVERLAY", "NumberFontNormalSmall")
     end
 
     -- Keybind (slot-level)
     if not btn.keybind then
-        btn.keybind = btn:CreateFontString(nil, "OVERLAY", "NumberFontNormalSmall")
+        btn.keybind = overlay:CreateFontString(nil, "OVERLAY", "NumberFontNormalSmall")
         btn.keybind:SetShadowOffset(1, -1)
     end
 
     -- Interface Keybind (group-level toggle binding)
     if not btn.interfaceKeybind then
-        btn.interfaceKeybind = btn:CreateFontString(nil, "OVERLAY", "NumberFontNormalSmall")
+        btn.interfaceKeybind = overlay:CreateFontString(nil, "OVERLAY", "NumberFontNormalSmall")
         btn.interfaceKeybind:SetShadowOffset(1, -1)
     end
 
     -- Countdown (new)
     if not btn.countdown then
-        btn.countdown = btn:CreateFontString(nil, "OVERLAY", "NumberFontNormalSmall")
+        btn.countdown = overlay:CreateFontString(nil, "OVERLAY", "NumberFontNormalSmall")
         -- Default to center, but will be updated by Text_UpdateCountdown
     end
 
     -- Custom Text (stub – not populated yet, but the FontString is ready)
     if not btn.customText then
-        btn.customText = btn:CreateFontString(nil, "OVERLAY", "NumberFontNormalSmall")
+        btn.customText = overlay:CreateFontString(nil, "OVERLAY", "NumberFontNormalSmall")
     end
 
     btn._textReady = true
@@ -192,7 +200,8 @@ end
 function Wise:Text_UpdateCountdown(btn, groupName, text)
     if not btn.countdown then
         -- Create it if missing (should be created in CreateFontStrings, but safe fallback)
-        btn.countdown = btn:CreateFontString(nil, "OVERLAY", "NumberFontNormalSmall")
+        local parent = btn._textOverlay or btn
+        btn.countdown = parent:CreateFontString(nil, "OVERLAY", "NumberFontNormalSmall")
     end
     
     local _, _, fontPath, _, _, _, _, _, countdownTextSize, countdownTextPosition, _, _, _, _, _, showCountdownText = Wise:GetGroupDisplaySettings(groupName)

--- a/modules/Debug.lua
+++ b/modules/Debug.lua
@@ -20,6 +20,23 @@ function Wise:DebugPrint(...)
         local msg = string.format(...)
         print("|cff00ccff[Wise Debug]|r", msg)
 
+        -- Feed into MechanicLib debug buffer for console integration
+        if Wise.debugBuffer then
+            table.insert(Wise.debugBuffer, {
+                msg = msg,
+                time = GetTime(),
+            })
+            -- Cap buffer to prevent memory bloat
+            if #Wise.debugBuffer > 500 then
+                table.remove(Wise.debugBuffer, 1)
+            end
+        end
+
+        -- Log to Mechanic's console directly (if available)
+        if Wise.MechanicLib and Wise.MechanicLib.Log then
+            Wise.MechanicLib:Log("Wise", msg, Wise.MechanicLib.Categories and Wise.MechanicLib.Categories.CORE or nil)
+        end
+
         if Wise.LogFrame then
             local timestamp = date("%H:%M:%S")
             local current = Wise.LogFrame:GetText() or ""

--- a/modules/Tooltips.lua
+++ b/modules/Tooltips.lua
@@ -31,12 +31,8 @@ function Wise:AddInterfaceTooltip(btn)
         -- Check setting
         if not WiseDB.settings.showTooltips then return end
 
-        -- Check if button is an invisible empty slot
-        local groupName = self.groupName or (self:GetParent() and self:GetParent().groupName)
-        if groupName and Wise.GetGroupDisplaySettings then
-            local _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, tipHideEmpty = Wise:GetGroupDisplaySettings(groupName)
-            if tipHideEmpty and self.actionType == "empty" then return end
-        end
+        -- Empty slots are invisible space maintainers — no tooltip
+        if self.actionType == "empty" then return end
 
         -- Determine Anchor
         -- Using ANCHOR_CURSOR to avoid obscuring other ring buttons

--- a/tests.xml
+++ b/tests.xml
@@ -129,4 +129,27 @@
             <KeyValue key="clearAction" value="if Wise.OptionsFrame then Wise.OptionsFrame:Hide() end" type="string"/>
         </KeyValues>
     </Frame>
+
+    <Frame name="WiseDebugTest_EmptySlots" inherits="WiseDebugTestsData">
+        <KeyValues>
+            <KeyValue key="testName" value="Empty Slots Highlight" type="string"/>
+            <KeyValue key="instructions" value="1. Hover over the middle slot (the empty slot). It should NOT highlight or scale.\n2. Verify the empty slot acts as a spacer." type="string"/>
+            <KeyValue key="action" value="
+                WiseDB.groups['Test_EmptySlots'] = {
+                    type = 'line',
+                    dynamic = false,
+                    hideEmptySlots = true,
+                    actions = {
+                        [1] = {{type = 'spell', value = 118, name = 'Polymorph'}},
+                        [2] = {{type = 'empty', value = nil, name = 'Empty Slot'}},
+                        [3] = {{type = 'spell', value = 2139, name = 'Counterspell'}}
+                    },
+                    anchor = {point = 'CENTER', x = 0, y = 100}
+                }
+                Wise:UpdateGroupDisplay('Test_EmptySlots')
+                Wise.frames['Test_EmptySlots']:Show()
+            " type="string"/>
+            <KeyValue key="clearAction" value="if Wise.frames['Test_EmptySlots'] then Wise.frames['Test_EmptySlots']:Hide() end; WiseDB.groups['Test_EmptySlots'] = nil" type="string"/>
+        </KeyValues>
+    </Frame>
 </Ui>


### PR DESCRIPTION
This pull request fixes an issue where visually hidden empty slots in the Wise addon UI would still react to mouseovers.

**Changes:**
- Created a `IsHiddenEmptySlot` helper function in `core/GUI.lua`.
- Disabled `ApplyHoverScale` and `ShowHoverGlow` for empty slots when `hideEmptySlots` is true.
- Skipped the `OnEnter` highlight logic for these slots entirely.
- Added a `WiseDebugTest_EmptySlots` human verification test to `tests.xml`.

---
*PR created automatically by Jules for task [8646578798209940853](https://jules.google.com/task/8646578798209940853) started by @claytonkimber*